### PR TITLE
Sensor domain for energy sell/buy price

### DIFF
--- a/custom_components/solar_optimizer/config_flow.py
+++ b/custom_components/solar_optimizer/config_flow.py
@@ -32,10 +32,10 @@ solar_optimizer_schema = {
         selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN])
     ),
     vol.Required("sell_cost_entity_id"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain=[INPUT_NUMBER_DOMAIN])
+        selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN])
     ),
     vol.Required("buy_cost_entity_id"): selector.EntitySelector(
-        selector.EntitySelectorConfig(domain=[INPUT_NUMBER_DOMAIN])
+        selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN])
     ),
     vol.Required("sell_tax_percent_entity_id"): selector.EntitySelector(
         selector.EntitySelectorConfig(domain=[INPUT_NUMBER_DOMAIN])


### PR DESCRIPTION
Permits the selection of sensors to indicate energy buy and sell prices to use directly prices coming from energy integrations, which are exposed as sensors