### PR TITLE
precise exported and imported kwh should be strictly positive number (not zero)

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -96,8 +96,8 @@ Vous devez spécifier :
 1. le sensor qui donne la consommation nette instantanée du logement (elle doit être négative si la production dépasse la consommation). Ce chiffre est indiqué en Watt,
 2. le sensor qui donne la production photovoltaïque instantanée en Watt aussi,
 3. un sensor ou input_number qui donne le cout du kwh importée (requis: nombre strictement positif),
-4. un sensor ou input_number qui donne le prix du kwh exportée (requis: nombre strictement positif)(dépend de votre contrat),
-5. un sensor ou input_number qui donne la taxe applicable sur les kwh exportée (dépend de votre contrat)
+4. un sensor ou input_number qui donne le prix du kwh exportée (requis: nombre strictement positif)(dépend de votre contrat), on peut utiliser la même valeur/sensor que l'importée si pas de contrat de revente,
+5. un sensor ou input_number qui donne la taxe applicable sur les kwh exportée (chiffre postifi ou 0) (dépend de votre contrat)
 6. l'heure de début de journée. A cette heure les compteurs d'uitlisation des équipements sont remis à zéro. La valeur par défaut est 05:00. Elle doit être avant la première production et le plus tard possible pour les activations en heures creuses. Cf. ci-dessus.
 
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -95,8 +95,8 @@ Lors de l'ajout de l'intégration Solar Optimizer, la page de paramétrage suiva
 Vous devez spécifier :
 1. le sensor qui donne la consommation nette instantanée du logement (elle doit être négative si la production dépasse la consommation). Ce chiffre est indiqué en Watt,
 2. le sensor qui donne la production photovoltaïque instantanée en Watt aussi,
-3. un sensor ou input_number qui donne le cout du kwh importée,
-4. un sensor ou input_number qui donne le prix du kwh exortée (dépend de votre contrat),
+3. un sensor ou input_number qui donne le cout du kwh importée (requis: nombre strictement positif),
+4. un sensor ou input_number qui donne le prix du kwh exortée (requis: nombre strictement positif)(dépend de votre contrat),
 5. un sensor ou input_number qui donne la taxe applicable sur les kwh exortée (dépend de votre contrat)
 6. l'heure de début de journée. A cette heure les compteurs d'uitlisation des équipements sont remis à zéro. La valeur par défaut est 05:00. Elle doit être avant la première production et le plus tard possible pour les activations en heures creuses. Cf. ci-dessus.
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -96,8 +96,8 @@ Vous devez spécifier :
 1. le sensor qui donne la consommation nette instantanée du logement (elle doit être négative si la production dépasse la consommation). Ce chiffre est indiqué en Watt,
 2. le sensor qui donne la production photovoltaïque instantanée en Watt aussi,
 3. un sensor ou input_number qui donne le cout du kwh importée (requis: nombre strictement positif),
-4. un sensor ou input_number qui donne le prix du kwh exortée (requis: nombre strictement positif)(dépend de votre contrat),
-5. un sensor ou input_number qui donne la taxe applicable sur les kwh exortée (dépend de votre contrat)
+4. un sensor ou input_number qui donne le prix du kwh exportée (requis: nombre strictement positif)(dépend de votre contrat),
+5. un sensor ou input_number qui donne la taxe applicable sur les kwh exportée (dépend de votre contrat)
 6. l'heure de début de journée. A cette heure les compteurs d'uitlisation des équipements sont remis à zéro. La valeur par défaut est 05:00. Elle doit être avant la première production et le plus tard possible pour les activations en heures creuses. Cf. ci-dessus.
 
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -97,7 +97,7 @@ Vous devez spécifier :
 2. le sensor qui donne la production photovoltaïque instantanée en Watt aussi,
 3. un sensor ou input_number qui donne le cout du kwh importée (requis: nombre strictement positif),
 4. un sensor ou input_number qui donne le prix du kwh exportée (requis: nombre strictement positif)(dépend de votre contrat), on peut utiliser la même valeur/sensor que l'importée si pas de contrat de revente,
-5. un sensor ou input_number qui donne la taxe applicable sur les kwh exportée (chiffre postifi ou 0) (dépend de votre contrat)
+5. un sensor ou input_number qui donne la taxe applicable sur les kwh exportée (chiffre positif ou 0) (dépend de votre contrat)
 6. l'heure de début de journée. A cette heure les compteurs d'uitlisation des équipements sont remis à zéro. La valeur par défaut est 05:00. Elle doit être avant la première production et le plus tard possible pour les activations en heures creuses. Cf. ci-dessus.
 
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ When adding the Solar Optimizer integration, the following settings page opens:
 You must specify:
 1. the sensor which gives the instantaneous net consumption of the dwelling (it must be negative if production exceeds consumption). This figure is indicated in Watt,
 2. the sensor which gives the instantaneous photovoltaic production in Watt too,
-3. a sensor or input_number which gives the cost of the imported kwh,
-4. a sensor or input_number which gives the price of the exported kwh (depends on your contract),
+3. a sensor or input_number which gives the cost of the imported kwh (require: positive number, not zero),
+4. a sensor or input_number which gives the price of the exported kwh (require: positive number, not zero)(depends on your contract),
 5. a sensor or input_number which gives the applicable tax on the exported kwh (depends on your contract)
 6. the start time of the day. At this time the equipment usage counters are reset to zero. The default value is 05:00. It must be before the first production and as late as possible for activations during off-peak hours. See above.
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ You must specify:
 1. the sensor which gives the instantaneous net consumption of the dwelling (it must be negative if production exceeds consumption). This figure is indicated in Watt,
 2. the sensor which gives the instantaneous photovoltaic production in Watt too,
 3. a sensor or input_number which gives the cost of the imported kwh (require: positive number, not zero),
-4. a sensor or input_number which gives the price of the exported kwh (require: positive number, not zero)(depends on your contract),
-5. a sensor or input_number which gives the applicable tax on the exported kwh (depends on your contract)
+4. a sensor or input_number which gives the price of the exported kwh (require: positive number, not zero)(depends on your contract), can re-use same sensor/input_number as imported kwh if no have a resale contract.
+5. a sensor or input_number which gives the applicable tax on the exported kwh (require: postive number or zero)(depends on your contract)
 6. the start time of the day. At this time the equipment usage counters are reset to zero. The default value is 05:00. It must be before the first production and as late as possible for activations during off-peak hours. See above.
 
 These 5 pieces of information are necessary for the algorithm to work, so they are all mandatory. The fact that they are sensors or input_number allows to have values that are re-evaluated at each cycle. Consequently, switching to off-peak hours can modify the calculation and therefore the states of the equipment since the import becomes less expensive. So everything is dynamic and recalculated at each cycle.


### PR DESCRIPTION
Otherwise solar_optimizer will not work