### PR TITLE
Ensure power step is strictly positive in config_schema

### DIFF
--- a/custom_components/solar_optimizer/config_schema.py
+++ b/custom_components/solar_optimizer/config_schema.py
@@ -115,7 +115,7 @@ power_managed_device_schema = vol.Schema(
         )),
         vol.Optional(CONF_POWER_MIN, default=220): vol.Coerce(float),
         vol.Required(CONF_POWER_MAX): str,
-        vol.Optional(CONF_POWER_STEP, default=220): vol.Coerce(float),
+        vol.Optional(CONF_POWER_STEP, default=220): vol.All(vol.Coerce(float), vol.Range(min=0, min_included=False)),
         vol.Optional(CONF_CHECK_USABLE_TEMPLATE, default="{{ True }}"): str,
         vol.Optional(CONF_CHECK_ACTIVE_TEMPLATE): str,
         vol.Optional(CONF_DURATION_MIN, default="60"): selector.NumberSelector(selector.NumberSelectorConfig(min=0.0, max=1440, step=0.1, mode=selector.NumberSelectorMode.BOX)),


### PR DESCRIPTION
Hi Jean-Marc,

I’ve made a small change in `config_schema.py` to improve input validation for `CONF_POWER_STEP`.

Previously, negative or zero values could be entered in the “step” parameter of a power-managed device, which caused Home Assistant to crash (high CPU usage and memory overflow).  
To prevent this, I updated the schema to ensure that `CONF_POWER_STEP` must be a positive float value.

Change made:
    vol.Optional(CONF_POWER_STEP, default=220): vol.Coerce(float)
was replaced with:
    vol.Optional(CONF_POWER_STEP, default=220): vol.All(vol.Coerce(float), vol.Range(min=0, min_included=False))

This avoids invalid configurations and ensures better stability.

Maybe it would also be worth taking a look at other parameters to see if any of them could benefit from similar validation.

Have a nice day!


