### PR TITLE
feat(card): v1.4.0 — device status clarification, secondary info, per…

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -44,12 +44,18 @@
 - [Carte Lovelace officielle](#carte-lovelace-officielle)
   - [Informations globales](#informations-globales)
   - [Informations par équipement](#informations-par-équipement)
+  - [Statuts des équipements](#statuts-des-équipements)
+  - [Informations secondaires](#informations-secondaires)
   - [Barre d'historique d'activation](#barre-dhistorique-dactivation)
   - [Actions disponibles](#actions-disponibles)
   - [Utilisation de la carte officielle](#utilisation-de-la-carte-officielle)
 - [Les contributions sont les bienvenues !](#les-contributions-sont-les-bienvenues)
 
 > ![Nouveau](https://github.com/jmcollin78/solar_optimizer/blob/main/images/new-icon.png?raw=true) _*Nouveautés*_
+> * **release 3.8.0** :
+>   - **Clarification des statuts** : nouveau statut `MANUEL` (ambre) lorsqu'un équipement est physiquement actif mais la gestion SO est désactivée. La bordure gauche reflète désormais toujours l'état physique (vert = allumé, gris = éteint), indépendamment de l'état de contrôle SO. Cf. [Statuts des équipements](#statuts-des-équipements)
+>   - **Informations secondaires** : nouvelle option `secondary_info` pour afficher des informations personnalisées par équipement via des templates. Cf. [Informations secondaires](#informations-secondaires)
+>   - **Blocs fermés par défaut** : tous les blocs équipement sont fermés au premier chargement. L'état ouvert/fermé de chaque bloc est persisté dans le `localStorage` du navigateur.
 > * **release 3.7.0** :
 >   - ajout d'une carte Lovelace officielle native (`custom:solar-optimizer-card`) intégrée à l'intégration. Cf. [Carte Lovelace officielle](#carte-lovelace-officielle)
 > * **release 3.5.0** :
@@ -620,6 +626,39 @@ Lorsque le bloc est **déplié**, les détails suivants apparaissent :
 - Temps de marche / temps maximum journalier,
 - Seuil de SOC batterie (si configuré).
 
+## Statuts des équipements
+
+Chaque bloc équipement affiche un badge de statut et une bordure gauche colorée. Ces deux signaux sont **indépendants** :
+
+| Bordure gauche | Signification                                         |
+| -------------- | ----------------------------------------------------- |
+| 🟢 Verte        | L'équipement est **physiquement allumé**              |
+| 🟠 Orange       | L'équipement est **en attente** d'une prochaine dispo |
+| ⬜ Grise        | L'équipement est **physiquement éteint**              |
+
+| Badge         | Couleur | Signification                                                                       |
+| ------------- | ------- | ----------------------------------------------------------------------------------- |
+| **ACTIF**     | Vert    | Géré par SO et physiquement allumé                                                  |
+| **MANUEL**    | Ambre   | Physiquement allumé mais **gestion SO désactivée** — l'utilisateur a repris la main |
+| **ATTENTE**   | Orange  | Géré par SO, en attente d'un prochain créneau                                       |
+| **INACTIF**   | Gris    | Géré par SO et physiquement éteint                                                  |
+| **DÉSACTIVÉ** | Gris    | Gestion SO désactivée et équipement éteint                                          |
+
+Le statut `MANUEL` est le signal clé : l'équipement consomme mais Solar Optimizer n'est pas aux commandes. La bordure verte confirme l'état physique quelle que soit la configuration de contrôle SO.
+
+## Informations secondaires
+
+L'option `secondary_info` permet d'afficher des informations personnalisées par équipement (état d'un programme de lave-linge, statut d'un chargeur VE…). La valeur supporte des templates simples avec `states()` et `state_attr()`.
+
+```yaml
+type: custom:solar-optimizer-card
+secondary_info:
+  lave_linge: "Etat du lave-linge : {{ states('sensor.lave_linge_programme') }}"
+  borne_ve: "{{ state_attr('sensor.borne_ve', 'status') }}"
+```
+
+La clé est l'identifiant de l'équipement (la partie après `switch.solar_optimizer_`). La valeur rendue s'affiche au-dessus des indicateurs Utilisable / En attente / HC forcées lorsque le bloc est déplié.
+
 ## Barre d'historique d'activation
 
 Chaque équipement dispose d'une **barre horizontale d'historique d'activation**, toujours visible même lorsque le bloc est plié. Elle imite les barres natives des `binary_sensor` de Home Assistant :
@@ -654,6 +693,8 @@ Il suffit d'ajouter une carte de type `custom:solar-optimizer-card` à votre tab
 ```yaml
 type: custom:solar-optimizer-card
 ```
+
+Tous les blocs sont **fermés par défaut** au premier chargement. L'état ouvert/fermé de chaque bloc est automatiquement sauvegardé dans le `localStorage` du navigateur et restauré à la prochaine visite.
 
 La carte est également directement sélectionnable sous le nom **Solar Optimizer Card** dans l'éditeur visuel de cartes de Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 - [Official Lovelace Card](#official-lovelace-card)
   - [Global Information](#global-information)
   - [Per-Device Information](#per-device-information)
+  - [Device Status](#device-status)
+  - [Secondary Info](#secondary-info)
   - [Activation History Bar](#activation-history-bar)
   - [Available Actions](#available-actions)
   - [How to Use the Official Card](#how-to-use-the-official-card)
@@ -55,6 +57,10 @@
 
 
 >![New](https://github.com/jmcollin78/solar_optimizer/blob/main/images/new-icon.png?raw=true) _*News*_
+> * **release 3.8.0**:
+>   - **Device status clarification**: new `MANUAL` status (amber) when a device is physically active but SO management is disabled. The left border now always reflects the physical state (green = on, grey = off), independently of the SO control state. See [Device Status](#device-status)
+>   - **Secondary info**: new `secondary_info` option to display custom per-device information using templates. See [Secondary Info](#secondary-info)
+>   - **Collapsed by default**: all device blocks are collapsed on first load. The open/close state of each block is persisted in the browser `localStorage`.
 > * **release 3.7.0**:
 >   - added an official native Lovelace card (`custom:solar-optimizer-card`) bundled with the integration. See [Official Lovelace Card](#official-lovelace-card)
 > * **release 3.5.0**:
@@ -646,6 +652,39 @@ When **expanded**, the following details appear:
 - Daily on-time / maximum on-time,
 - Battery SOC threshold (if configured).
 
+## Device Status
+
+Each device block shows a status badge and a colored left border. The two signals are independent:
+
+| Left border | Meaning                                     |
+| ----------- | ------------------------------------------- |
+| 🟢 Green     | Device is **physically ON**                 |
+| 🟠 Orange    | Device is **waiting** for next availability |
+| ⬜ Grey      | Device is **physically OFF**                |
+
+| Badge        | Color  | Meaning                                                                      |
+| ------------ | ------ | ---------------------------------------------------------------------------- |
+| **ACTIVE**   | Green  | Managed by SO and physically on                                              |
+| **MANUAL**   | Amber  | Physically on but **SO management disabled** — user has taken manual control |
+| **WAITING**  | Orange | Managed by SO, waiting for next available slot                               |
+| **INACTIVE** | Grey   | Managed by SO and physically off                                             |
+| **DISABLED** | Grey   | SO management disabled and device is off                                     |
+
+The `MANUAL` status is the key signal: it means the device is consuming power but Solar Optimizer is not in control. The green border confirms the physical state regardless of the SO control state.
+
+## Secondary Info
+
+You can display custom per-device information (e.g. washing machine program, EV charger status) using the `secondary_info` option. The value supports simple templates with `states()` and `state_attr()`.
+
+```yaml
+type: custom:solar-optimizer-card
+secondary_info:
+  washing_machine: "Washing machine status: {{ states('sensor.washing_machine_program') }}"
+  ev_charger: "{{ state_attr('sensor.ev_charger', 'status') }}"
+```
+
+The key is the device ID (the part after `switch.solar_optimizer_`). The rendered value appears above the Usable / Waiting / Off-peak indicators when the block is expanded.
+
 ## Activation History Bar
 
 Each device has a **horizontal activation history bar**, always visible even when the block is collapsed. It mimics the native Home Assistant `binary_sensor` history bars:
@@ -680,6 +719,8 @@ Simply add a card of type `custom:solar-optimizer-card` into your Lovelace dashb
 ```yaml
 type: custom:solar-optimizer-card
 ```
+
+All blocks are **collapsed by default** on first load. The open/close state of each block is automatically saved in the browser's `localStorage` and restored on the next visit.
 
 The card is also fully registered in Home Assistant's card editor list under the name **Solar Optimizer Card**.
 

--- a/custom_components/solar_optimizer/frontend/solar-optimizer-card.js
+++ b/custom_components/solar_optimizer/frontend/solar-optimizer-card.js
@@ -4,6 +4,7 @@ const TRANSLATIONS = {
     active: 'Actif',
     waiting: 'Attente',
     inactive: 'Inactif',
+    manual: 'Manuel',
     usable: 'Utilisable',
     waitingIndicator: 'En attente',
     offpeakForced: 'HC forcées',
@@ -39,6 +40,7 @@ const TRANSLATIONS = {
     editorAutoConfig: 'Cette carte est configurée de façon automatique.',
     editorDesc: 'Elle scanne et agrège automatiquement les mesures de l\'algorithme ainsi que tous vos commutateurs et entités de priorité commençant par <code>solar_optimizer</code>.',
     editorNote: '<strong>Note :</strong> Aucun paramètre optionnel ou configuration YAML supplémentaire n\'est nécessaire pour le fonctionnement de cette carte !',
+    editorSecondaryInfoDesc: 'Affichez des informations personnalisées par appareil (supporte <code>states()</code> et <code>state_attr()</code>) :',
     cardDescription: 'Carte interactive pour contrôler et suivre les appareils gérés par le planificateur de charges Solar Optimizer.',
   },
   en: {
@@ -46,6 +48,7 @@ const TRANSLATIONS = {
     active: 'Active',
     waiting: 'Waiting',
     inactive: 'Inactive',
+    manual: 'Manual',
     usable: 'Usable',
     waitingIndicator: 'Waiting',
     offpeakForced: 'Off-peak forced',
@@ -81,6 +84,7 @@ const TRANSLATIONS = {
     editorAutoConfig: 'This card is automatically configured.',
     editorDesc: 'It automatically scans and aggregates algorithm measurements and all your switches and priority entities starting with <code>solar_optimizer</code>.',
     editorNote: '<strong>Note:</strong> No optional parameters or additional YAML configuration are needed for this card to work!',
+    editorSecondaryInfoDesc: 'Display custom info per device (supports <code>states()</code> and <code>state_attr()</code>):',
     cardDescription: 'Interactive card to control and monitor devices managed by the Solar Optimizer load scheduler.',
   }
 };
@@ -162,7 +166,6 @@ class SolarOptimizerCard extends HTMLElement {
             background-color: color-mix(in srgb, var(--warning-color, #ff9800) 5%, var(--card-background-color, #fff));
           }
           solar-optimizer-card .so-device-card-disabled {
-            border-left-color: var(--disabled-text-color, #9e9e9e);
             background-color: color-mix(in srgb, var(--disabled-text-color, #9e9e9e) 5%, var(--card-background-color, #fff));
           }
           solar-optimizer-card .so-device-card-inactive {
@@ -205,6 +208,10 @@ class SolarOptimizerCard extends HTMLElement {
           }
           solar-optimizer-card .so-badge-waiting {
             background-color: var(--warning-color, #ff9800);
+            color: white;
+          }
+          solar-optimizer-card .so-badge-manual {
+            background-color: #f59e0b;
             color: white;
           }
           solar-optimizer-card .so-indicators {
@@ -364,6 +371,16 @@ class SolarOptimizerCard extends HTMLElement {
             border-radius: 4px;
             overflow: hidden;
           }
+          solar-optimizer-card .so-secondary-info {
+            font-size: 0.82em;
+            color: var(--secondary-text-color);
+            background-color: var(--secondary-background-color, #f5f5f5);
+            border-radius: 6px;
+            padding: 4px 8px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+          }
         </style>
         <ha-card header="Solar Optimizer">
           <div class="so-card-body" id="content" style="display:block;width:100%;box-sizing:border-box;padding:16px;"></div>
@@ -421,7 +438,7 @@ class SolarOptimizerCard extends HTMLElement {
     // État global : tous pliés ?
     const allCollapsed = devicesSwitches.length > 0 && devicesSwitches.every(k => {
       const id = k.replace("switch.solar_optimizer_", "");
-      return this._collapsedDevices[id] === true;
+      return this._collapsedDevices[id] !== false;
     });
 
     let devicesHtml = "";
@@ -465,7 +482,9 @@ class SolarOptimizerCard extends HTMLElement {
       const powerPercent = totalRange > 0 ? Math.round(((currentPower - powerMin) / totalRange) * 100) : (currentPower > 0 ? 100 : 0);
 
       let statusBadge = "";
-      if (!isEnabled) {
+      if (!isEnabled && isActive) {
+        statusBadge = `<span class="so-badge so-badge-manual">${t('manual')}</span>`;
+      } else if (!isEnabled) {
         statusBadge = `<span class="so-badge so-badge-inactive">${t('disabled')}</span>`;
       } else if (isActive) {
         statusBadge = `<span class="so-badge so-badge-active">${t('active')}</span>`;
@@ -474,6 +493,16 @@ class SolarOptimizerCard extends HTMLElement {
       } else {
         statusBadge = `<span class="so-badge so-badge-inactive">${t('inactive')}</span>`;
       }
+
+      // Informations secondaires configurées par l'utilisateur
+      const secondaryInfoTemplate = this._config?.secondary_info?.[deviceId] || null;
+      const secondaryInfoValue = secondaryInfoTemplate ? this._evaluateTemplate(secondaryInfoTemplate) : null;
+      const secondaryInfoHtml = secondaryInfoValue
+        ? `<div class="so-secondary-info">
+            <ha-icon icon="mdi:information-outline" style="--mdi-icon-size: 14px; flex-shrink:0;"></ha-icon>
+            <span>${secondaryInfoValue}</span>
+          </div>`
+        : '';
 
       // Indicateurs booléens
       const indicatorsHtml = `
@@ -560,12 +589,12 @@ class SolarOptimizerCard extends HTMLElement {
         </div>
       `;
 
-      const isCollapsed = this._collapsedDevices[deviceId] === true;
+      const isCollapsed = this._collapsedDevices[deviceId] !== false;
       const chevronClass = isCollapsed ? 'so-collapse-btn collapsed' : 'so-collapse-btn';
-      const cardStateClass = !isEnabled ? 'so-device-card-disabled'
-        : isActive ? 'so-device-card-active'
-          : isWaiting ? 'so-device-card-waiting'
-            : 'so-device-card-inactive';
+      const physicalClass = isActive ? 'so-device-card-active'
+        : isWaiting ? 'so-device-card-waiting'
+          : 'so-device-card-inactive';
+      const cardStateClass = !isEnabled ? `${physicalClass} so-device-card-disabled` : physicalClass;
 
       devicesHtml += `
         <div class="so-device-card ${cardStateClass}" data-device-id="${deviceId}">
@@ -591,6 +620,7 @@ class SolarOptimizerCard extends HTMLElement {
             ` : ''}
           </div>
           <div class="so-device-details${isCollapsed ? ' hidden' : ''}">
+            ${secondaryInfoHtml}
             ${indicatorsHtml}
             <div class="so-device-meta">
               <div>${t('requiredPower')}: <strong>${requestedPower} W</strong></div>
@@ -712,6 +742,7 @@ class SolarOptimizerCard extends HTMLElement {
         e.stopPropagation();
         const deviceId = btn.getAttribute("data-collapse-id");
         this._collapsedDevices[deviceId] = !this._collapsedDevices[deviceId];
+        try { localStorage.setItem('solar-optimizer-card-collapsed', JSON.stringify(this._collapsedDevices)); } catch(e) {}
         this.updateCard();
       });
     });
@@ -725,6 +756,7 @@ class SolarOptimizerCard extends HTMLElement {
           const id = k.replace("switch.solar_optimizer_", "");
           this._collapsedDevices[id] = !allCollapsed;
         });
+        try { localStorage.setItem('solar-optimizer-card-collapsed', JSON.stringify(this._collapsedDevices)); } catch(e) {}
         this.updateCard();
       });
     }
@@ -754,7 +786,14 @@ class SolarOptimizerCard extends HTMLElement {
 
   setConfig(config) {
     this._config = config;
-    if (!this._collapsedDevices) this._collapsedDevices = {};
+    if (!this._collapsedDevices) {
+      try {
+        const saved = localStorage.getItem('solar-optimizer-card-collapsed');
+        this._collapsedDevices = saved ? JSON.parse(saved) : {};
+      } catch (e) {
+        this._collapsedDevices = {};
+      }
+    }
     if (!this._historyCache) this._historyCache = {};
     if (!this._fetchingHistory) this._fetchingHistory = new Set();
     if (!this._powerHistoryCache) this._powerHistoryCache = {};
@@ -869,6 +908,17 @@ class SolarOptimizerCard extends HTMLElement {
       </div>`;
   }
 
+  _evaluateTemplate(template) {
+    if (!template || !this._hass) return null;
+    return template
+      .replace(/\{\{\s*states\(['"]([^'"]+)['"]\)\s*\}\}/g, (_, entityId) => {
+        return this._hass.states[entityId]?.state ?? 'unknown';
+      })
+      .replace(/\{\{\s*state_attr\(['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\)\s*\}\}/g, (_, entityId, attr) => {
+        return this._hass.states[entityId]?.attributes?.[attr] ?? 'unknown';
+      });
+  }
+
   _renderHistoryBar(entityId, t) {
     const CACHE_TTL = 5 * 60 * 1000;
     if (!this._historyCache) this._historyCache = {};
@@ -977,6 +1027,12 @@ class SolarOptimizerCardEditor extends HTMLElement {
           <input type="number" id="so-history-hours-input" min="1" max="168" value="${historyHours}"
             style="width: 72px; padding: 4px 8px; border-radius: 4px; border: 1px solid var(--divider-color, #ccc); background: var(--card-background-color, #fff); color: var(--primary-text-color); font-size: 0.9em;">
         </div>
+        <div style="margin-top: 16px;">
+          <p style="font-size: 0.9em; color: var(--primary-text-color); margin-bottom: 4px;">${t('editorSecondaryInfoDesc')}</p>
+          <pre style="font-size: 0.78em; background: var(--secondary-background-color, #f5f5f5); padding: 8px; border-radius: 4px; overflow-x: auto; color: var(--primary-text-color); margin: 0;">secondary_info:
+  device_id: "{{ states('sensor.my_entity') }}"
+  device_id2: "{{ state_attr('sensor.my_entity', 'attribute') }}"</pre>
+        </div>
       </div>
     `;
 
@@ -998,7 +1054,7 @@ customElements.define("solar-optimizer-card-editor", SolarOptimizerCardEditor);
 
 // Afficher un log au démarrage dans la console du navigateur avec la version de la carte
 console.info(
-  `%c  SOLAR-OPTIMIZER-CARD  %c Version 1.3.0 `,
+  `%c  SOLAR-OPTIMIZER-CARD  %c Version 1.4.0 `,
   "color: white; background: #4caf50; font-weight: bold;",
   "color: #4caf50; background: white; font-weight: bold; border: 1px solid #4caf50;"
 );

--- a/custom_components/solar_optimizer/manifest.json
+++ b/custom_components/solar_optimizer/manifest.json
@@ -13,5 +13,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/jmcollin78/solar_optimizer/issues",
     "quality_scale": "silver",
-    "version": "3.7.0"
+    "version": "3.8.0"
 }

--- a/tech-docs/so-card-specifications.md
+++ b/tech-docs/so-card-specifications.md
@@ -39,6 +39,60 @@ Chaque info doit être affichée avec un icone qui la représente le mieux.
 Le bloc pour chaque équipement est pliable et dépliable. Lorsqu'il est plié, seuls les infos de nom, état, puissance courante / puissance max, bouton start/stop et bouton enable sont visibles.
 Un chevron global permet de tout plier / déplier.
 
+**Comportement par défaut** : tous les blocs sont fermés au premier chargement de la carte. L'état ouvert/fermé de chaque bloc est persisté dans le `localStorage` du navigateur sous la clé `solar-optimizer-card-collapsed` et restauré automatiquement à la prochaine visite.
+
+## Les statuts d'un équipement
+
+Chaque bloc équipement affiche un badge de statut et une bordure gauche colorée. Ces deux signaux sont **indépendants** :
+
+### Bordure gauche — état physique
+
+| Couleur                    | Signification                                                 |
+| -------------------------- | ------------------------------------------------------------- |
+| Verte (`--success-color`)  | L'équipement est **physiquement allumé**                      |
+| Orange (`--warning-color`) | L'équipement est **en attente** d'une prochaine disponibilité |
+| Grise (`--divider-color`)  | L'équipement est **physiquement éteint**                      |
+
+La bordure gauche reflète **toujours** l'état physique réel du switch, indépendamment de l'état de contrôle SO. En cas de gestion SO désactivée (`!isEnabled`), un fond gris clair est superposé via la classe `so-device-card-disabled`, mais la couleur de la bordure reste celle de l'état physique.
+
+### Badge de statut — état de contrôle SO
+
+| Badge         | Couleur           | Condition                              | Signification                                                                   |
+| ------------- | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| **ACTIF**     | Vert              | `isEnabled && isActive`                | Géré par SO et physiquement allumé                                              |
+| **MANUEL**    | Ambre (`#f59e0b`) | `!isEnabled && isActive`               | Physiquement allumé mais gestion SO désactivée — l'utilisateur a repris la main |
+| **ATTENTE**   | Orange            | `isEnabled && !isActive && isWaiting`  | Géré par SO, en attente d'un prochain créneau                                   |
+| **INACTIF**   | Gris              | `isEnabled && !isActive && !isWaiting` | Géré par SO et physiquement éteint                                              |
+| **DÉSACTIVÉ** | Gris              | `!isEnabled && !isActive`              | Gestion SO désactivée et équipement éteint                                      |
+
+Le statut `MANUEL` est le signal critique : il indique que l'équipement consomme de l'énergie mais que Solar Optimizer n'en a pas le contrôle.
+
+## Les informations secondaires
+
+Chaque bloc équipement peut afficher une ligne d'information personnalisée, configurée via l'option `secondary_info`. Cette information est rendue **au-dessus** des indicateurs Utilisable / En attente / HC forcées, uniquement lorsque le bloc est déplié.
+
+La valeur est un template évalué côté client supportant :
+- `{{ states('entity_id') }}` → état de l'entité
+- `{{ state_attr('entity_id', 'attribute') }}` → valeur d'un attribut
+
+### Option de configuration
+
+| Paramètre        | Type     | Valeur par défaut | Description                   |
+| ---------------- | -------- | ----------------- | ----------------------------- |
+| `secondary_info` | `object` | `null`            | Map de `device_id → template` |
+
+La clé est l'identifiant de l'équipement (partie après `switch.solar_optimizer_`).
+
+Exemple YAML :
+```yaml
+type: custom:solar-optimizer-card
+secondary_info:
+  lave_linge: "{{ states('sensor.lave_linge_programme') }}"
+  borne_ve: "{{ state_attr('sensor.borne_ve', 'status') }}"
+```
+
+Si la clé n'est pas renseignée pour un équipement, rien n'est affiché.
+
 ## La barre d'historique d'activation
 
 Chaque équipement dispose d'une barre horizontale d'historique d'activation, **toujours visible** (même lorsque la carte est pliée), placée juste en dessous de la barre de puissance.
@@ -52,9 +106,9 @@ Chaque équipement dispose d'une barre horizontale d'historique d'activation, **
 
 ### Option de configuration
 
-| Paramètre | Type | Valeur par défaut | Description |
-|---|---|---|---|
-| `history_hours` | `number` | `24` | Durée en heures de la fenêtre d'historique affichée |
+| Paramètre       | Type     | Valeur par défaut | Description                                         |
+| --------------- | -------- | ----------------- | --------------------------------------------------- |
+| `history_hours` | `number` | `24`              | Durée en heures de la fenêtre d'historique affichée |
 
 Exemple YAML :
 ```yaml


### PR DESCRIPTION
…sistent collapse state

## Device status (Options A+C)

- Add `MANUAL` (amber) badge when a device is physically ON but SO management is disabled — the user has taken manual control
- The left border now always reflects the **physical state** (green = on, orange = waiting, grey = off), independently of the SO control state
- `.so-device-card-disabled` no longer sets `border-left-color`; the grey background overlay is combined with the physical border class instead
- 5-state badge cascade: MANUAL / DISABLED / ACTIVE / WAITING / INACTIVE

## Secondary info

- New `secondary_info` YAML option: a map of `device_id → template string`
- Client-side template evaluation via `_evaluateTemplate()` supporting `{{ states('entity_id') }}` and `{{ state_attr('entity_id', 'attr') }}`
- Rendered value displayed above the Usable/Waiting/Off-peak indicators when the block is expanded
- New `.so-secondary-info` CSS class (info icon + grey pill)
- Visual editor updated with a `secondary_info` YAML example

## Persistent collapse state

- All device blocks are **collapsed by default** on first load (`_collapsedDevices[id] !== false` sentinel)
- `setConfig` reads initial state from `localStorage` key `solar-optimizer-card-collapsed`
- Individual chevron and global chevron both write back to `localStorage` on every toggle (wrapped in try/catch for private-mode safety)

## Docs

- README.md and README-fr.md updated with release 3.8.0 news, new ToC entries, Device Status table, Secondary Info section, and collapsed-by-default behaviour description

Files changed:
- custom_components/solar_optimizer/frontend/solar-optimizer-card.js
- config/www/solar-optimizer-card.js
- README.md
- README-fr.md