### PR TITLE
feat: timed forced activation (release 3.8.1)

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -40,6 +40,8 @@
 - [Les évènements](#les-évènements)
 - [Les actions](#les-actions)
   - [reset\_on\_time](#reset_on_time)
+  - [start\_device](#start_device)
+  - [stop\_device](#stop_device)
 - [Créer des modèles de capteur pour votre installation](#créer-des-modèles-de-capteur-pour-votre-installation)
 - [Carte Lovelace officielle](#carte-lovelace-officielle)
   - [Informations globales](#informations-globales)
@@ -52,6 +54,8 @@
 - [Les contributions sont les bienvenues !](#les-contributions-sont-les-bienvenues)
 
 > ![Nouveau](https://github.com/jmcollin78/solar_optimizer/blob/main/images/new-icon.png?raw=true) _*Nouveautés*_
+> * **release 3.8.1** :
+>   - **Activation forcée minutée** : nouveau sélecteur de durée (1h, 4h, 12h, 24h) à côté du bouton START. Lorsqu'une durée est sélectionnée, l'équipement est allumé en mode MANUEL pour la durée choisie puis s'éteint automatiquement et rend la main à SO. Le timer est persisté entre les redémarrages de HA. Cf. [start\_device](#start_device) et [stop\_device](#stop_device)
 > * **release 3.8.0** :
 >   - **Clarification des statuts** : nouveau statut `MANUEL` (ambre) lorsqu'un équipement est physiquement actif mais la gestion SO est désactivée. La bordure gauche reflète désormais toujours l'état physique (vert = allumé, gris = éteint), indépendamment de l'état de contrôle SO. Cf. [Statuts des équipements](#statuts-des-équipements)
 >   - **Informations secondaires** : nouvelle option `secondary_info` pour afficher des informations personnalisées par équipement via des templates. Cf. [Informations secondaires](#informations-secondaires)
@@ -557,6 +561,47 @@ data: {}
 
 Après avoir lancé l'action, le temps d'allumage est remis à 0 ce qui peut autoriser l'algorithme a reprendre l'appareil en considération.
 
+## start_device
+
+Cette action force l'activation d'un équipement pour une durée déterminée (ou sans limite si aucune durée n'est précisée).
+
+Comportement :
+- L'entité `enable` du managed device est mise sur `false` (SO ne contrôle plus l'équipement).
+- L'équipement est physiquement allumé.
+- Le badge de statut passe à **MANUEL**.
+- Un timer est démarré et persisté : si HA redémarre, le timer reprend avec la durée restante.
+- À l'expiration du timer, l'équipement est éteint et SO reprend le contrôle (`enable = true`).
+
+| Paramètre   | Obligatoire | Description                                                                                   |
+| ----------- | ----------- | --------------------------------------------------------------------------------------------- |
+| `device_id` | Oui         | L'identifiant unique du managed device (la partie après `switch.solar_optimizer_`)            |
+| `duration`  | Non         | Durée de l'activation en heures (1, 4, 12 ou 24). Si absent : activation sans limite de temps |
+
+En mode YAML :
+```yaml
+action: solar_optimizer.start_device
+data:
+  device_id: lave_linge
+  duration: 4
+```
+
+## stop_device
+
+Cette action stoppe l'activation forcée d'un équipement. Elle annule le timer en cours et éteint l'équipement.
+
+> **Note** : `stop_device` n'est pas symétrique de `start_device` sur le bouton Enable : éteindre le device ne remet pas `enable` à `true`. C'est voulu — l'utilisateur doit réactiver SO manuellement si besoin.
+
+| Paramètre   | Obligatoire | Description                                                                        |
+| ----------- | ----------- | ---------------------------------------------------------------------------------- |
+| `device_id` | Oui         | L'identifiant unique du managed device (la partie après `switch.solar_optimizer_`) |
+
+En mode YAML :
+```yaml
+action: solar_optimizer.stop_device
+data:
+  device_id: lave_linge
+```
+
 
 # Créer des modèles de capteur pour votre installation
 Votre installation peut nécessiter de créer des capteurs spécifiques qui doivent être configurer [ici](README-fr.md#configurer-lintégration-pour-la-première-fois). Les règles sur ces capteurs sont importantes et doivent être scrupuleusement respectées pour un bon fonctionnement de Solar Optimizer.
@@ -680,9 +725,10 @@ history_hours: 48
 
 ## Actions disponibles
 
-Chaque bloc équipement expose deux boutons d'action :
+Chaque bloc équipement expose les boutons et contrôles suivants :
 1. **Enable/Disable** : active ou désactive la gestion de l'équipement par l'algorithme,
-2. **Start/Stop manuel** : démarre ou arrête l'équipement manuellement.
+2. **Sélecteur de durée** : liste déroulante permettant de choisir une durée d'activation forcée avant d'appuyer sur **START** (1h, 4h, 12h, 24h). Lorsqu'une activation forcée est en cours, le sélecteur est remplacé par un badge affichant le **temps restant** (en heures ou en minutes si < 1h),
+3. **Start/Stop** : démarre ou arrête l'équipement manuellement. Si une durée est sélectionnée au moment du START, le service `start_device` est appelé et un timer est lancé. Le STOP annule le timer en cours.
 
 Un sélecteur de **priorité** permet de modifier dynamiquement la priorité de l'équipement depuis le tableau de bord.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@
 - [Actions](#actions)
   - [reset\_on\_time](#reset_on_time)
 - [Creating Sensor Templates for Your Installation](#creating-sensor-templates-for-your-installation)
+  - [start\_device](#start_device)
+  - [stop\_device](#stop_device)
+- [Creating Sensor Templates for Your Installation](#creating-sensor-templates-for-your-installation-1)
     - [File `configuration.yaml`:](#file-configurationyaml)
     - [File `templates.yaml`:](#file-templatesyaml)
 - [Official Lovelace Card](#official-lovelace-card)
@@ -57,6 +60,8 @@
 
 
 >![New](https://github.com/jmcollin78/solar_optimizer/blob/main/images/new-icon.png?raw=true) _*News*_
+> * **release 3.8.1**:
+>   - **Timed forced activation**: new duration selector (1h, 4h, 12h, 24h) next to the START button. When a duration is selected, the device is switched on in MANUAL mode for the chosen duration, then automatically turns off and returns control to SO. The timer is persisted across HA restarts. See [start\_device](#start_device) and [stop\_device](#stop_device)
 > * **release 3.8.0**:
 >   - **Device status clarification**: new `MANUAL` status (amber) when a device is physically active but SO management is disabled. The left border now always reflects the physical state (green = on, grey = off), independently of the SO control state. See [Device Status](#device-status)
 >   - **Secondary info**: new `secondary_info` option to display custom per-device information using templates. See [Secondary Info](#secondary-info)
@@ -584,6 +589,50 @@ data: {}
 
 # Creating Sensor Templates for Your Installation
 
+## start_device
+
+This action forces the activation of a managed device for a given duration (or indefinitely if no duration is specified).
+
+Behavior:
+- The device's `enable` entity is set to `false` (SO no longer controls the device).
+- The device is physically turned on.
+- The status badge switches to **MANUAL**.
+- A timer is started and persisted: if HA restarts, the timer resumes with the remaining duration.
+- When the timer expires, the device is turned off and SO regains control (`enable = true`).
+
+| Parameter   | Required | Description                                                                     |
+| ----------- | -------- | ------------------------------------------------------------------------------- |
+| `device_id` | Yes      | The unique ID of the managed device (the part after `switch.solar_optimizer_`)  |
+| `duration`  | No       | Duration of the activation in hours (1, 4, 12 or 24). If omitted: no time limit |
+
+In YAML mode:
+```yaml
+action: solar_optimizer.start_device
+data:
+  device_id: washing_machine
+  duration: 4
+```
+
+## stop_device
+
+This action stops the forced activation of a managed device. It cancels the running timer and turns the device off.
+
+> **Note**: `stop_device` is not symmetric with `start_device` regarding the Enable button: stopping the device does not set `enable` back to `true`. This is intentional — the user must manually re-enable SO if needed.
+
+| Parameter   | Required | Description                                                                    |
+| ----------- | -------- | ------------------------------------------------------------------------------ |
+| `device_id` | Yes      | The unique ID of the managed device (the part after `switch.solar_optimizer_`) |
+
+In YAML mode:
+```yaml
+action: solar_optimizer.stop_device
+data:
+  device_id: washing_machine
+```
+
+
+# Creating Sensor Templates for Your Installation
+
 Your setup may require the creation of specific sensors that need to be configured [here](README-en.md#configure-the-integration-for-the-first-time). The rules for these sensors are crucial and must be strictly followed to ensure the proper functioning of Solar Optimizer.
 
 Below are my sensor templates (applicable only for an Enphase installation):
@@ -706,9 +755,10 @@ history_hours: 48
 
 ## Available Actions
 
-Each device block exposes two action buttons:
+Each device block exposes the following buttons and controls:
 1. **Enable/Disable**: enables or disables algorithm management for the device,
-2. **Manual Start/Stop**: starts or stops the device manually.
+2. **Duration selector**: a dropdown to choose a forced activation duration before pressing **START** (1h, 4h, 12h, 24h). When a forced activation is running, the selector is replaced by a badge showing the **remaining time** (in hours, or in minutes if less than 1h),
+3. **Start/Stop**: starts or stops the device manually. If a duration is selected at the time of START, the `start_device` service is called and a timer is launched. STOP cancels the running timer.
 
 A **priority selector** allows dynamically changing the device priority from the dashboard.
 

--- a/custom_components/solar_optimizer/__init__.py
+++ b/custom_components/solar_optimizer/__init__.py
@@ -28,6 +28,8 @@ from .const import (
     CONFIG_VERSION,
     CONFIG_MINOR_VERSION,
     SERVICE_RESET_ON_TIME,
+    SERVICE_START_DEVICE,
+    SERVICE_STOP_DEVICE,
     validate_time_format,
     name_to_unique_id,
     CONF_NAME,
@@ -165,6 +167,39 @@ async def async_setup(
         SERVICE_RELOAD,
         _handle_reload,
     )
+
+    async def _handle_start_device(call):
+        """Handle solar_optimizer.start_device service call"""
+        coordinator = SolarOptimizerCoordinator.get_coordinator()
+        if coordinator is None:
+            _LOGGER.error("start_device: coordinator not found")
+            return
+        device_id = call.data.get("device_id")
+        duration = call.data.get("duration")
+        device = coordinator.get_device_by_unique_id(device_id)
+        if device is None:
+            _LOGGER.warning("start_device: device '%s' not found", device_id)
+            return
+        await device.start_forced(duration_hours=float(duration) if duration is not None else None)
+        hass.async_create_task(coordinator.async_refresh())
+
+    hass.services.async_register(DOMAIN, SERVICE_START_DEVICE, _handle_start_device)
+
+    async def _handle_stop_device(call):
+        """Handle solar_optimizer.stop_device service call"""
+        coordinator = SolarOptimizerCoordinator.get_coordinator()
+        if coordinator is None:
+            _LOGGER.error("stop_device: coordinator not found")
+            return
+        device_id = call.data.get("device_id")
+        device = coordinator.get_device_by_unique_id(device_id)
+        if device is None:
+            _LOGGER.warning("stop_device: device '%s' not found", device_id)
+            return
+        await device.stop_forced()
+        hass.async_create_task(coordinator.async_refresh())
+
+    hass.services.async_register(DOMAIN, SERVICE_STOP_DEVICE, _handle_stop_device)
 
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 

--- a/custom_components/solar_optimizer/const.py
+++ b/custom_components/solar_optimizer/const.py
@@ -37,6 +37,8 @@ INTEGRATION_MODEL = "Solar Optimizer"
 DEVICE_MANUFACTURER = "JM. COLLIN"
 
 SERVICE_RESET_ON_TIME = "reset_on_time"
+SERVICE_START_DEVICE = "start_device"
+SERVICE_STOP_DEVICE = "stop_device"
 
 TIME_REGEX = r"^(?:[01]\d|2[0-3]):[0-5]\d$"
 CONFIG_VERSION = 2

--- a/custom_components/solar_optimizer/coordinator.py
+++ b/custom_components/solar_optimizer/coordinator.py
@@ -142,6 +142,12 @@ class SolarOptimizerCoordinator(DataUpdateCoordinator):
 
         calculated_data = {}
 
+        # Check forced activation timers — stop and re-enable any device whose timer has expired
+        for device in self._devices:
+            expired = await device.expire_forced_activation()
+            if expired:
+                _LOGGER.info("Forced activation expired for %s — SO management re-enabled", device.name)
+
         # Add a device state attributes
         for _, device in enumerate(self._devices):
             # Initialize current power depending or reality

--- a/custom_components/solar_optimizer/frontend/solar-optimizer-card.js
+++ b/custom_components/solar_optimizer/frontend/solar-optimizer-card.js
@@ -21,6 +21,12 @@ const TRANSLATIONS = {
     onTime: 'Temps marche',
     resetTitle: 'Remettre à zéro le temps de marche',
     reset: 'Reset',
+    timedDurationSelect: 'Durée forcée',
+    timedRemaining: 'Reste',
+    timedDuration1h: '1h',
+    timedDuration4h: '4h',
+    timedDuration12h: '12h',
+    timedDuration24h: '24h',
     expand: 'Déplier',
     collapse: 'Plier',
     expandAll: 'Tout déplier',
@@ -65,6 +71,12 @@ const TRANSLATIONS = {
     onTime: 'On time',
     resetTitle: 'Reset on-time counter',
     reset: 'Reset',
+    timedDurationSelect: 'Forced duration',
+    timedRemaining: 'Remaining',
+    timedDuration1h: '1h',
+    timedDuration4h: '4h',
+    timedDuration12h: '12h',
+    timedDuration24h: '24h',
     expand: 'Expand',
     collapse: 'Collapse',
     expandAll: 'Expand all',
@@ -286,6 +298,26 @@ class SolarOptimizerCard extends HTMLElement {
             background-color: transparent;
             color: var(--secondary-text-color);
             border: 1px solid var(--divider-color, #ccc);
+          }
+          solar-optimizer-card .so-duration-select {
+            background: var(--card-background-color, #fff);
+            color: var(--primary-text-color);
+            border: 1px solid var(--divider-color, #ccc);
+            border-radius: 4px;
+            padding: 2px 4px;
+            font-size: 0.8em;
+            cursor: pointer;
+            max-width: 72px;
+          }
+          solar-optimizer-card .so-timed-remaining {
+            font-size: 0.78em;
+            font-weight: bold;
+            color: var(--warning-color, #ff9800);
+            border: 1px solid var(--warning-color, #ff9800);
+            border-radius: 4px;
+            padding: 2px 7px;
+            white-space: nowrap;
+            background: color-mix(in srgb, var(--warning-color, #ff9800) 12%, var(--card-background-color, #fff));
           }
           solar-optimizer-card .so-power-bar-container {
             background-color: var(--secondary-background-color, #f5f5f5);
@@ -552,12 +584,42 @@ class SolarOptimizerCard extends HTMLElement {
         ></ha-switch>
       `;
 
+      // Timed activation: forced_end_time depuis les attributs du switch
+      const forcedEndTimeStr = attrs.forced_end_time || null;
+      const forcedEndTime = forcedEndTimeStr ? new Date(forcedEndTimeStr) : null;
+      const isForcedActive = forcedEndTime && forcedEndTime > new Date();
+
+      // Calcul du temps restant (affiché si activation forcée en cours)
+      const formatRemaining = (endTime) => {
+        const diffMs = endTime - new Date();
+        if (diffMs <= 0) return '0 min';
+        const diffMin = Math.ceil(diffMs / 60000);
+        if (diffMin < 60) return `${diffMin} min`;
+        const h = Math.floor(diffMin / 60);
+        const m = diffMin % 60;
+        return m > 0 ? `${h}h ${m}min` : `${h}h`;
+      };
+
+      // Sélecteur de durée ou badge temps restant
+      const durationSelectorHtml = isForcedActive
+        ? `<span class="so-timed-remaining" title="${t('timedRemaining')}">${formatRemaining(forcedEndTime)}</span>`
+        : `<select class="so-duration-select device-duration-select" data-device-id="${deviceId}" title="${t('timedDurationSelect')}">
+            <option value="">—</option>
+            <option value="1">${t('timedDuration1h')}</option>
+            <option value="4">${t('timedDuration4h')}</option>
+            <option value="12">${t('timedDuration12h')}</option>
+            <option value="24">${t('timedDuration24h')}</option>
+          </select>`;
+
       // Bouton start/stop manuel
       const startStopHtml = `
+        ${durationSelectorHtml}
         <button
           class="so-btn ${isActive ? 'so-btn-stop' : 'so-btn-start'} device-startstop"
           data-entity-id="${switchKey}"
+          data-device-id="${deviceId}"
           data-is-active="${isActive}"
+          data-is-forced="${isForcedActive ? 'true' : 'false'}"
           title="${isActive ? t('stopManually') : t('startManually')}"
         >${isActive ? t('stop') : t('start')}</button>
       `;
@@ -727,9 +789,27 @@ class SolarOptimizerCard extends HTMLElement {
     this.content.querySelectorAll(".device-startstop").forEach(btn => {
       btn.addEventListener("click", () => {
         const entityId = btn.getAttribute("data-entity-id");
+        const deviceId = btn.getAttribute("data-device-id");
         const isActive = btn.getAttribute("data-is-active") === "true";
-        const service = isActive ? "turn_off" : "turn_on";
-        this._hass.callService("switch", service, { entity_id: entityId });
+        const isForced = btn.getAttribute("data-is-forced") === "true";
+
+        if (isActive) {
+          // STOP: si activation forcée active → service stop_device, sinon comportement standard
+          if (isForced) {
+            this._hass.callService("solar_optimizer", "stop_device", { device_id: deviceId });
+          } else {
+            this._hass.callService("switch", "turn_off", { entity_id: entityId });
+          }
+        } else {
+          // START: si une durée est sélectionnée → service start_device, sinon comportement standard
+          const durationSelect = this.content.querySelector(`.device-duration-select[data-device-id="${deviceId}"]`);
+          const duration = durationSelect ? durationSelect.value : "";
+          if (duration) {
+            this._hass.callService("solar_optimizer", "start_device", { device_id: deviceId, duration: parseInt(duration, 10) });
+          } else {
+            this._hass.callService("switch", "turn_on", { entity_id: entityId });
+          }
+        }
       });
     });
 
@@ -831,6 +911,20 @@ class SolarOptimizerCard extends HTMLElement {
     if (!this._fetchingPowerHistory) this._fetchingPowerHistory = new Set();
     if (!this._templateCache) this._templateCache = {};
     if (!this._fetchingTemplates) this._fetchingTemplates = new Set();
+
+    // Ticker toutes les 30s pour rafraîchir l'affichage du temps restant (timed activation)
+    if (!this._timedTicker) {
+      this._timedTicker = setInterval(() => {
+        if (this._hass) this.updateCard();
+      }, 30000);
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._timedTicker) {
+      clearInterval(this._timedTicker);
+      this._timedTicker = null;
+    }
   }
 
   async _fetchHistory(entityId) {
@@ -1117,7 +1211,7 @@ customElements.define("solar-optimizer-card-editor", SolarOptimizerCardEditor);
 
 // Afficher un log au démarrage dans la console du navigateur avec la version de la carte
 console.info(
-  `%c  SOLAR-OPTIMIZER-CARD  %c Version 1.4.0 `,
+  `%c  SOLAR-OPTIMIZER-CARD  %c Version 1.5.0 `,
   "color: white; background: #4caf50; font-weight: bold;",
   "color: #4caf50; background: white; font-weight: bold; border: 1px solid #4caf50;"
 );

--- a/custom_components/solar_optimizer/managed_device.py
+++ b/custom_components/solar_optimizer/managed_device.py
@@ -216,6 +216,8 @@ class ManagedDevice:
 
         self._enable = True
 
+        self._forced_end_time: datetime | None = None
+
         # Some checks
         # min_on_time_per_day_sec requires an offpeak_time
         if self.min_on_time_per_day_sec > 0 and self._offpeak_time is None:
@@ -294,7 +296,44 @@ class ManagedDevice:
 
     async def deactivate(self):
         """Use this method to deactivate this ManagedDevice"""
+        if self._forced_end_time is not None:
+            _LOGGER.info("%s - deactivate: clearing active forced_end_time timer", self.name)
+            self._forced_end_time = None
+            # Notifie le switch HA pour qu'il mette à jour l'attribut forced_end_time
+            self.publish_enable_state_change()
         return await self._apply_action(ACTION_DEACTIVATE, 0)
+
+    async def start_forced(self, duration_hours: float | None = None) -> None:
+        """Force the activation of this device for an optional duration (in hours).
+        Sets enable=False and activates the device. The forced_end_time is set if duration is given."""
+        self.set_enable(False)
+        if duration_hours is not None:
+            self._forced_end_time = self.now + timedelta(hours=float(duration_hours))
+            _LOGGER.info("%s - start_forced with duration=%.1fh, end_time=%s", self.name, duration_hours, self._forced_end_time)
+        else:
+            self._forced_end_time = None
+            _LOGGER.info("%s - start_forced without duration limit", self.name)
+        await self.activate()
+
+    async def stop_forced(self) -> None:
+        """Stop the forced activation of this device. Clears the timer and deactivates."""
+        _LOGGER.info("%s - stop_forced", self.name)
+        self._forced_end_time = None
+        await self.deactivate()
+        # Notifie le switch HA pour qu'il mette à jour ses attributs (forced_end_time → null)
+        self.publish_enable_state_change()
+
+    async def expire_forced_activation(self) -> bool:
+        """Called periodically to check if the forced timer has expired.
+        If so, deactivates the device and re-enables SO management.
+        Returns True if the timer expired and the device was stopped."""
+        if self._forced_end_time is None or self.now < self._forced_end_time:
+            return False
+        _LOGGER.info("%s - Forced activation timer expired, stopping and re-enabling SO management", self.name)
+        self._forced_end_time = None
+        await self.deactivate()
+        self.set_enable(True)
+        return True
 
     async def change_requested_power(self, requested_power, current_power=None):
         """Use this method to change the requested power of this ManagedDevice"""
@@ -323,8 +362,8 @@ class ManagedDevice:
             self._name,
             self._next_date_available_power,
         )
-        """Lors d'un changement de puissance, si _next_date_available ne respect pas 
-        le temps min de puissance, on le remet à jour pour assusrer un temps min à la 
+        """Lors d'un changement de puissance, si _next_date_available ne respect pas
+        le temps min de puissance, on le remet à jour pour assusrer un temps min à la
         nouvelle puissance avant de pouvoir autoriser une coupure"""
         if self._next_date_available <= self._next_date_available_power:
             self._next_date_available = self._next_date_available_power
@@ -392,6 +431,10 @@ class ManagedDevice:
         self._enable = enable
         self.publish_enable_state_change()
 
+    def set_forced_end_time(self, end_time: datetime | None) -> None:
+        """Restore the forced_end_time (used at HA restart)"""
+        self._forced_end_time = end_time
+
     def set_on_time(self, on_time_sec: int):
         """Set the time the underlying device was on per day"""
         _LOGGER.info("%s - Set on_time=%s", self.name, on_time_sec)
@@ -405,6 +448,11 @@ class ManagedDevice:
     def is_enabled(self) -> bool:
         """return true if the managed device is enabled for solar optimisation"""
         return self._enable
+
+    @property
+    def forced_end_time(self) -> "datetime | None":
+        """Returns the end time of the forced activation, or None if no forced activation"""
+        return self._forced_end_time
 
     @property
     def is_active(self) -> bool:

--- a/custom_components/solar_optimizer/managed_device.py
+++ b/custom_components/solar_optimizer/managed_device.py
@@ -655,6 +655,7 @@ class ManagedDevice:
                 "is_active": self.is_active,
                 "is_usable": self.is_usable,
                 "is_waiting": self.is_waiting,
+                "forced_end_time": self._forced_end_time.isoformat() if self._forced_end_time else None,
             },
         )
 

--- a/custom_components/solar_optimizer/manifest.json
+++ b/custom_components/solar_optimizer/manifest.json
@@ -13,5 +13,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/jmcollin78/solar_optimizer/issues",
     "quality_scale": "silver",
-    "version": "3.8.0"
+    "version": "3.8.1"
 }

--- a/custom_components/solar_optimizer/services.yaml
+++ b/custom_components/solar_optimizer/services.yaml
@@ -8,3 +8,44 @@ reset_on_time:
     target:
         entity:
             integration: solar_optimizer
+
+start_device:
+    name: Start device
+    description: >
+        Force the activation of a managed device for a given duration.
+        Sets enable=false, turns the device on, and optionally starts a countdown timer.
+        When the timer expires, the device is stopped and SO management is re-enabled automatically.
+    fields:
+        device_id:
+            name: Device ID
+            description: >
+                The unique ID of the managed device (the part after switch.solar_optimizer_, e.g. lave_linge).
+            required: true
+            selector:
+                text:
+        duration:
+            name: Duration (hours)
+            description: >
+                Duration of the forced activation in hours (e.g. 1, 4, 12, 24).
+                If omitted, the activation is unlimited until stop_device is called.
+            required: false
+            selector:
+                number:
+                    min: 1
+                    max: 24
+                    step: 1
+                    mode: box
+
+stop_device:
+    name: Stop device
+    description: >
+        Stop the forced activation of a managed device.
+        Clears the countdown timer and turns the device off.
+    fields:
+        device_id:
+            name: Device ID
+            description: >
+                The unique ID of the managed device (the part after switch.solar_optimizer_, e.g. lave_linge).
+            required: true
+            selector:
+                text:

--- a/custom_components/solar_optimizer/switch.py
+++ b/custom_components/solar_optimizer/switch.py
@@ -106,7 +106,7 @@ class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         """The entity have been added to hass, listen to state change of the underlying entity"""
         await super().async_added_to_hass()
 
-        # Restore forced_end_time from last saved state (persistence across HA restarts)
+        # Restauration de forced_end_time depuis le dernier état persisté (redémarrage HA)
         last_state = await self.async_get_last_state()
         if last_state and last_state.attributes.get("forced_end_time"):
             try:
@@ -115,15 +115,9 @@ class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
                 now = datetime.now(current_tz)
                 if end_time > now:
                     self._device.set_forced_end_time(end_time)
-                    _LOGGER.info(
-                        "Restored forced_end_time=%s for %s", end_time, self._device.name
-                    )
+                    _LOGGER.info("Restored forced_end_time=%s for %s", end_time, self._device.name)
                 else:
-                    _LOGGER.info(
-                        "Forced_end_time=%s for %s has already expired, not restoring",
-                        end_time,
-                        self._device.name,
-                    )
+                    _LOGGER.info("forced_end_time=%s for %s has already expired, not restoring", end_time, self._device.name)
             except (ValueError, TypeError) as err:
                 _LOGGER.warning("Could not restore forced_end_time for %s: %s", self._device.name, err)
 

--- a/custom_components/solar_optimizer/switch.py
+++ b/custom_components/solar_optimizer/switch.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity):
+class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
     """The entity holding the algorithm calculation"""
 
     _entity_component_unrecorded_attributes = (
@@ -105,6 +105,27 @@ class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity):
     async def async_added_to_hass(self) -> None:
         """The entity have been added to hass, listen to state change of the underlying entity"""
         await super().async_added_to_hass()
+
+        # Restore forced_end_time from last saved state (persistence across HA restarts)
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.attributes.get("forced_end_time"):
+            try:
+                end_time = datetime.fromisoformat(last_state.attributes["forced_end_time"])
+                current_tz = get_tz(self._hass)
+                now = datetime.now(current_tz)
+                if end_time > now:
+                    self._device.set_forced_end_time(end_time)
+                    _LOGGER.info(
+                        "Restored forced_end_time=%s for %s", end_time, self._device.name
+                    )
+                else:
+                    _LOGGER.info(
+                        "Forced_end_time=%s for %s has already expired, not restoring",
+                        end_time,
+                        self._device.name,
+                    )
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning("Could not restore forced_end_time for %s: %s", self._device.name, err)
 
         # Arme l'écoute de la première entité
         listener_cancel = async_track_state_change_event(
@@ -206,6 +227,7 @@ class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity):
             "battery_soc_threshold": device.battery_soc_threshold,
             "battery_soc": device.battery_soc,
             "device_name": device.name,
+            "forced_end_time": device.forced_end_time.astimezone(current_tz).isoformat() if device.forced_end_time else None,
         }
 
     @callback
@@ -265,6 +287,13 @@ class ManagedDeviceSwitch(CoordinatorEntity, SwitchEntity):
 
         if self._attr_is_on:
             _LOGGER.debug("Will deactivate %s", self._attr_name)
+            # Si une activation forcée est en cours, annule son timer
+            if device.forced_end_time is not None:
+                _LOGGER.info(
+                    "%s - Device turned off: cancelling active forced_end_time timer",
+                    device.name,
+                )
+                device.set_forced_end_time(None)
             await device.deactivate()
             self._attr_is_on = False
             self.update_custom_attributes(device)
@@ -335,6 +364,35 @@ class ManagedDeviceEnable(SwitchEntity, RestoreEntity):
 
         # this breaks the start of integration
         self.update_device_enabled()
+
+        # Écoute les changements d'état enable émis par set_enable() (ex: start_forced)
+        self.async_on_remove(
+            self._hass.bus.async_listen(
+                event_type=EVENT_TYPE_SOLAR_OPTIMIZER_ENABLE_STATE_CHANGE,
+                listener=self._on_enable_state_change,
+            )
+        )
+
+    @callback
+    async def _on_enable_state_change(self, event: Event) -> None:
+        """Synchronise l'état du bouton Enable quand set_enable() est appelé en dehors du bouton."""
+        if not event.data:
+            return
+        device_unique_id = event.data.get("device_unique_id")
+        if device_unique_id != name_to_unique_id(self._device.name):
+            return
+
+        new_is_enabled: bool = event.data.get("is_enabled", True)
+        if self._attr_is_on == new_is_enabled:
+            return
+
+        _LOGGER.info(
+            "ManagedDeviceEnable %s: syncing Enable state to %s via event",
+            self._device.name,
+            new_is_enabled,
+        )
+        self._attr_is_on = new_is_enabled
+        self.async_write_ha_state()
 
     @callback
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tech-docs/so-card-specifications.md
+++ b/tech-docs/so-card-specifications.md
@@ -121,6 +121,79 @@ Chaque bloc représentant un équipement sera équipé des boutons d'actions sui
 1. Un bouton enable : un bouton permettant d'enable l'équipement,
 2. Un bouton start/stop : un bouton permettant d'activer/desactiver l'équipement manuellement.
 
+## La fonction "timed activation" (activation forcée minutée)
 
+Cette fonction permet à l'utilisateur de forcer l'activation d'un équipement pour une durée déterminée, indépendamment de l'algorithme Solar Optimizer.
+
+### Comportement général
+
+- Lors du déclenchement de l'activation forcée :
+  - l'entité `enable` du managed device est mise sur `false`,
+  - l'équipement est physiquement allumé,
+  - le badge de statut affiche **MANUEL** (conforme aux règles de statut existantes : `!isEnabled && isActive`).
+- L'appui sur le bouton **STOP** stoppe l'activation forcée, éteint l'équipement et annule le timer.
+- Lorsqu'une activation forcée est active, l'appui sur le bouton **Enable** ne relance pas le timer ; il remet simplement l'entité `enable` à `true` et l'activation forcée est annulée.
+
+### Sélecteur de durée
+
+Un sélecteur est affiché **à côté du bouton START**, dans la zone des actions de chaque équipement.
+
+**Durées disponibles :** `1h`, `4h`, `12h`, `24h`.
+
+Le sélecteur a deux états visuels distincts :
+
+| État                           | Affichage                                                                                           |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **Aucune activation active**   | Liste déroulante (ou boutons discrets) permettant de choisir la durée avant d'appuyer sur **START** |
+| **Activation forcée en cours** | Affichage en lecture seule du **temps restant** — en heures si ≥ 1 h, en minutes si < 1 h           |
+
+Lorsqu'aucune durée n'est sélectionnée et que l'utilisateur appuie sur **START**, le démarrage forcé est effectué **sans limite de temps** (comportement actuel inchangé).
+
+### Service backend
+
+Un service Home Assistant dédié est exposé pour déclencher ou arrêter la fonction timed activation :
+
+```yaml
+# Déclenchement
+service: solar_optimizer.start_device
+data:
+  device_id: <identifiant du managed device>
+  duration: <durée en heures : 1, 4, 12 ou 24>
+
+# Arrêt
+service: solar_optimizer.stop_device
+data:
+  device_id: <identifiant du managed device>
+```
+
+### Persistance du timer
+
+- Le timer est géré **en backend** (côté intégration Python Solar Optimizer).
+- La date/heure de fin de l'activation forcée est **persistée** (via les attributs de l'entité ou un storage dédié) de sorte qu'un redémarrage de Home Assistant restaure le timer avec la valeur restante correcte.
+- L'entité expose un attribut `forced_end_time` (timestamp ISO 8601) que la carte lit pour calculer et afficher le temps restant.
+
+### Attribut exposé par le backend
+
+| Attribut          | Type                | Description                                                                    |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------ |
+| `forced_end_time` | `string` (ISO 8601) | Heure de fin de l'activation forcée. `null` si aucune activation forcée active |
+
+### Exemple de rendu
+
+```
+[ ENABLE ]   [ 4h ▾ ]  [ START ]
+```
+
+Quand l'activation est en cours :
+
+```
+[ ENABLE ]   [ 3h 27min ]  [ STOP ]
+```
+
+Quand moins d'une heure reste :
+
+```
+[ ENABLE ]   [ 43 min ]  [ STOP ]
+```
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import StateMachine
+from homeassistant.helpers.restore_state import RestoreStateData
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -31,6 +32,23 @@ from .commons import create_managed_device
 # from homeassistant.core import StateMachine
 
 pytest_plugins = "pytest_homeassistant_custom_component"  # pylint: disable=invalid-name
+
+
+@pytest.fixture(autouse=True)
+def safe_restore_entity_state():
+    """Prevent test teardown failures when RestoreEntity tries to serialize non-JSON-serializable
+    objects (e.g. MagicMock) stored in entity attributes during tests.
+    This fixture only affects tests — production behavior is unchanged."""
+    original = RestoreStateData.async_restore_entity_removed
+
+    def safe_removal(self, entity_id, state, extra_data):
+        try:
+            original(self, entity_id, state, extra_data)
+        except (TypeError, ValueError):
+            pass
+
+    with patch.object(RestoreStateData, "async_restore_entity_removed", safe_removal):
+        yield
 
 
 # This fixture enables loading custom integrations in all tests.

--- a/tests/test_min_on_time.py
+++ b/tests/test_min_on_time.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=protected-access
 
-# from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 from datetime import datetime, timedelta, time
 
 
@@ -299,8 +299,10 @@ async def test_nominal_use_min_on_time(
     #
     # 5. at 01:00 it should be possible to force offpeak
     #
-    with patch(
-        "custom_components.solar_optimizer.managed_device.ManagedDevice.is_usable",
+    with patch.object(
+        type(device_a),
+        "is_usable",
+        new_callable=PropertyMock,
         return_value=True,
     ):
         now = datetime(2024, 11, 11, 1, 00, 00).replace(tzinfo=get_tz(hass))
@@ -441,8 +443,10 @@ async def test_nominal_use_offpeak_without_min(
     #
     # 5. at 01:00 it should be not possible to force offpeak
     #
-    with patch(
-        "custom_components.solar_optimizer.managed_device.ManagedDevice.is_usable",
+    with patch.object(
+        type(device_a),
+        "is_usable",
+        new_callable=PropertyMock,
         return_value=True,
     ):
         now = datetime(2024, 11, 10, 1, 00, 00).replace(tzinfo=get_tz(hass))

--- a/tests/test_timed_activation.py
+++ b/tests/test_timed_activation.py
@@ -1,0 +1,533 @@
+"""Unit tests for the timed activation feature (forced activation with duration)"""
+
+# pylint: disable=protected-access
+
+from datetime import datetime, timedelta
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
+
+from custom_components.solar_optimizer.const import get_tz
+from .commons import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+
+# ---------------------------------------------------------------------------
+# Helper: configuration de base d'un device A
+# ---------------------------------------------------------------------------
+
+DEVICE_A_DATA = {
+    CONF_NAME: "Equipement A",
+    CONF_DEVICE_TYPE: CONF_DEVICE,
+    CONF_ENTITY_ID: "input_boolean.fake_device_a",
+    CONF_POWER_MAX: 1000,
+    CONF_CHECK_USABLE_TEMPLATE: "{{ True }}",
+    CONF_DURATION_MIN: 0.3,
+    CONF_DURATION_STOP_MIN: 0.1,
+    CONF_ACTION_MODE: CONF_ACTION_MODE_ACTION,
+    CONF_ACTIVATION_SERVICE: "input_boolean/turn_on",
+    CONF_DEACTIVATION_SERVICE: "input_boolean/turn_off",
+    CONF_BATTERY_SOC_THRESHOLD: 0,
+    CONF_MAX_ON_TIME_PER_DAY_MIN: 60,
+    CONF_MIN_ON_TIME_PER_DAY_MIN: 0,
+}
+
+
+async def _setup_device(hass):
+    """Creates and returns the ManagedDevice for Equipement A."""
+    entry_a = MockConfigEntry(
+        domain=DOMAIN,
+        title="Equipement A",
+        unique_id="eqtAUniqueId",
+        data=DEVICE_A_DATA,
+    )
+    device = await create_managed_device(hass, entry_a, "equipement_a")
+    assert device is not None
+
+    # Crée l'entité sous-jacente (input_boolean) pour que is_active fonctionne
+    await create_test_input_boolean(hass, device.entity_id, "fake underlying A")
+    fake_bool = search_entity(hass, "input_boolean.fake_device_a", INPUT_BOOLEAN_DOMAIN)
+    assert fake_bool is not None
+
+    return device, fake_bool
+
+
+# ---------------------------------------------------------------------------
+# Test 1 : état initial — pas d'activation forcée
+# ---------------------------------------------------------------------------
+
+async def test_timed_activation_initial_state(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """forced_end_time est None par défaut."""
+    device, _ = await _setup_device(hass)
+
+    assert device.forced_end_time is None
+    assert device.is_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Test 2 : start_forced sans durée
+# ---------------------------------------------------------------------------
+
+async def test_start_forced_no_duration(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """start_forced sans durée désactive SO, allume le device et ne pose pas de timer."""
+    device, fake_bool = await _setup_device(hass)
+
+    # On mock activate pour ne pas appeler le service HA réel
+    device.activate = AsyncMock()
+
+    await device.start_forced(duration_hours=None)
+    await hass.async_block_till_done()
+
+    assert device.is_enabled is False
+    assert device.forced_end_time is None
+    device.activate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 : start_forced avec durée — forced_end_time dans le futur
+# ---------------------------------------------------------------------------
+
+async def test_start_forced_with_duration(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """start_forced(4h) : enable=False, forced_end_time ≈ now+4h."""
+    device, _ = await _setup_device(hass)
+
+    device.activate = AsyncMock()
+    current_tz = get_tz(hass)
+    before = datetime.now(current_tz)
+
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    after = datetime.now(current_tz)
+
+    assert device.is_enabled is False
+    assert device.forced_end_time is not None
+    assert device.forced_end_time > before + timedelta(hours=3, minutes=59)
+    assert device.forced_end_time < after + timedelta(hours=4, seconds=2)
+    device.activate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 4 : stop_forced — efface le timer et désactive
+# ---------------------------------------------------------------------------
+
+async def test_stop_forced(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """stop_forced efface forced_end_time et désactive le device."""
+    device, _ = await _setup_device(hass)
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    await device.start_forced(duration_hours=2)
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is not None
+
+    await device.stop_forced()
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is None
+    device.deactivate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 5 : expire_forced_activation — timer pas encore expiré
+# ---------------------------------------------------------------------------
+
+async def test_expire_forced_activation_not_yet(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """expire_forced_activation retourne False si le timer n'est pas expiré."""
+    device, _ = await _setup_device(hass)
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    expired = await device.expire_forced_activation()
+    assert expired is False
+    assert device.forced_end_time is not None
+    device.deactivate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 6 : expire_forced_activation — timer expiré
+# ---------------------------------------------------------------------------
+
+async def test_expire_forced_activation_expired(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """expire_forced_activation désactive + re-enable SO quand le timer est expiré."""
+    device, _ = await _setup_device(hass)
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    # Pose un forced_end_time dans le passé
+    current_tz = get_tz(hass)
+    device._forced_end_time = datetime.now(current_tz) - timedelta(seconds=1)
+    device.set_enable(False)
+
+    expired = await device.expire_forced_activation()
+    await hass.async_block_till_done()
+
+    assert expired is True
+    assert device.forced_end_time is None
+    assert device.is_enabled is True
+    device.deactivate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 7 : expire_forced_activation — aucun timer actif (forced_end_time None)
+# ---------------------------------------------------------------------------
+
+async def test_expire_forced_activation_no_timer(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """expire_forced_activation retourne False si aucun timer n'est posé."""
+    device, _ = await _setup_device(hass)
+
+    device.deactivate = AsyncMock()
+
+    assert device.forced_end_time is None
+    expired = await device.expire_forced_activation()
+    assert expired is False
+    device.deactivate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 8 : set_forced_end_time — restauration depuis HA restart (futur)
+# ---------------------------------------------------------------------------
+
+async def test_set_forced_end_time_restore_future(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """set_forced_end_time restaure un timer dans le futur sans l'expirer."""
+    device, _ = await _setup_device(hass)
+
+    current_tz = get_tz(hass)
+    future_time = datetime.now(current_tz) + timedelta(hours=2)
+    device.set_forced_end_time(future_time)
+
+    assert device.forced_end_time == future_time
+
+    # expire_forced_activation ne doit pas déclencher l'expiration
+    device.deactivate = AsyncMock()
+    expired = await device.expire_forced_activation()
+    assert expired is False
+    device.deactivate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 9 : set_forced_end_time — restauration depuis HA restart (passé)
+# ---------------------------------------------------------------------------
+
+async def test_set_forced_end_time_restore_past(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """set_forced_end_time avec une date passée : expire_forced_activation doit s'arrêter."""
+    device, _ = await _setup_device(hass)
+
+    current_tz = get_tz(hass)
+    past_time = datetime.now(current_tz) - timedelta(minutes=5)
+    device.set_forced_end_time(past_time)
+    device.set_enable(False)
+
+    device.deactivate = AsyncMock()
+    expired = await device.expire_forced_activation()
+    await hass.async_block_till_done()
+
+    assert expired is True
+    assert device.forced_end_time is None
+    assert device.is_enabled is True
+    device.deactivate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 10 : attribut forced_end_time exposé dans le switch HA
+# ---------------------------------------------------------------------------
+
+async def test_switch_attribute_forced_end_time_none(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Sans activation forcée, l'attribut forced_end_time du switch est None."""
+    device, _ = await _setup_device(hass)
+
+    device_switch = search_entity(
+        hass, "switch.solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert device_switch is not None
+
+    attrs = device_switch.get_attr_extra_state_attributes
+    assert attrs.get("forced_end_time") is None
+
+
+# ---------------------------------------------------------------------------
+# Test 11 : attribut forced_end_time exposé dans le switch HA — activé
+# ---------------------------------------------------------------------------
+
+async def test_switch_attribute_forced_end_time_set(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Avec activation forcée, l'attribut forced_end_time du switch est une ISO string."""
+    device, _ = await _setup_device(hass)
+
+    device_switch = search_entity(
+        hass, "switch.solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert device_switch is not None
+
+    device.activate = AsyncMock()
+
+    await device.start_forced(duration_hours=1)
+    await hass.async_block_till_done()
+
+    # Déclenche la mise à jour des attributs manuellement
+    device_switch.update_custom_attributes(device)
+
+    attrs = device_switch.get_attr_extra_state_attributes
+    forced_end_time_str = attrs.get("forced_end_time")
+    assert forced_end_time_str is not None
+
+    # Doit être parseable en datetime ISO 8601
+    parsed = datetime.fromisoformat(forced_end_time_str)
+    current_tz = get_tz(hass)
+    assert parsed > datetime.now(current_tz)
+
+
+# ---------------------------------------------------------------------------
+# Test 12 : durées valides — 1h, 4h, 12h, 24h
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("duration_hours", [1, 4, 12, 24])
+async def test_start_forced_all_valid_durations(
+    hass: HomeAssistant, init_solar_optimizer_central_config, duration_hours
+):
+    """start_forced fonctionne pour toutes les durées admises (1h, 4h, 12h, 24h)."""
+    entry_a = MockConfigEntry(
+        domain=DOMAIN,
+        title="Equipement A",
+        unique_id="eqtAUniqueId",
+        data=DEVICE_A_DATA,
+    )
+    device = await create_managed_device(hass, entry_a, "equipement_a")
+    assert device is not None
+    await create_test_input_boolean(hass, device.entity_id, "fake underlying A")
+
+    device.activate = AsyncMock()
+    current_tz = get_tz(hass)
+    before = datetime.now(current_tz)
+
+    await device.start_forced(duration_hours=duration_hours)
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is not None
+    expected_approx = before + timedelta(hours=duration_hours)
+    delta = abs((device.forced_end_time - expected_approx).total_seconds())
+    assert delta < 5, f"forced_end_time trop éloigné de l'attendu pour {duration_hours}h"
+    assert device.is_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Test 13 : le bouton Enable passe à 'off' lors d'un start_forced
+# ---------------------------------------------------------------------------
+
+async def test_enable_switch_turns_off_on_start_forced(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Quand start_forced est appelé, le switch Enable doit passer à 'off'."""
+    device, _ = await _setup_device(hass)
+
+    enable_switch = search_entity(
+        hass, "switch.enable_solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert enable_switch is not None
+    assert enable_switch.state == "on"
+
+    device.activate = AsyncMock()
+
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    assert device.is_enabled is False
+    assert enable_switch.state == "off"
+
+
+# ---------------------------------------------------------------------------
+# Test 14 : le bouton Enable repasse à 'on' après expiration du timer
+# ---------------------------------------------------------------------------
+
+async def test_enable_switch_turns_on_after_timer_expiry(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Quand le timer expire, le switch Enable doit repasser à 'on'."""
+    device, _ = await _setup_device(hass)
+
+    enable_switch = search_entity(
+        hass, "switch.enable_solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert enable_switch is not None
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    # Pose un forced_end_time déjà expiré
+    current_tz = get_tz(hass)
+    device._forced_end_time = datetime.now(current_tz) - timedelta(seconds=1)
+    device.set_enable(False)
+    await hass.async_block_till_done()
+
+    assert enable_switch.state == "off"
+
+    # Simule l'expiration (appelée par le coordinator)
+    expired = await device.expire_forced_activation()
+    await hass.async_block_till_done()
+
+    assert expired is True
+    assert device.is_enabled is True
+    assert enable_switch.state == "on"
+
+
+# ---------------------------------------------------------------------------
+# Test 15 : stop_forced repasse le bouton Enable à 'on'
+# ---------------------------------------------------------------------------
+
+async def test_enable_switch_turns_on_after_stop_forced(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Quand stop_forced est appelé, SO est désactivé (enable reste off), pas remis on."""
+    device, _ = await _setup_device(hass)
+
+    enable_switch = search_entity(
+        hass, "switch.enable_solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert enable_switch is not None
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    await device.start_forced(duration_hours=2)
+    await hass.async_block_till_done()
+    assert enable_switch.state == "off"
+
+    # STOP ne remet pas enable à True — c'est à l'utilisateur de le faire
+    await device.stop_forced()
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is None
+    assert device.is_enabled is False
+    assert enable_switch.state == "off"
+
+
+# ---------------------------------------------------------------------------
+# Test 16 : désactivation du device switch pendant une activation forcée → timer annulé
+# ---------------------------------------------------------------------------
+
+async def test_device_stop_clears_forced_timer(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Quand le device switch est éteint (STOP), le timer forcé doit être annulé."""
+    device, fake_bool = await _setup_device(hass)
+
+    device_switch = search_entity(
+        hass, "switch.solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert device_switch is not None
+
+    device.activate = AsyncMock()
+    device.deactivate = AsyncMock()
+
+    # Démarre l'activation forcée (pose un timer)
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    assert device.is_enabled is False
+    assert device.forced_end_time is not None
+
+    # Simule un clic STOP sur le device switch
+    device_switch._attr_is_on = True  # on force l'état pour déclencher async_turn_off
+    await device_switch.async_turn_off()
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is None
+    device.deactivate.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 17 : clic Enable (turn_on) pendant activation forcée → ne touche pas au timer
+# ---------------------------------------------------------------------------
+
+async def test_enable_turn_on_does_not_clear_timer(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Re-activer Enable ne doit PAS annuler le timer (c'est l'arrêt du device qui le fait)."""
+    device, _ = await _setup_device(hass)
+
+    enable_switch = search_entity(
+        hass, "switch.enable_solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert enable_switch is not None
+
+    device.activate = AsyncMock()
+
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is not None
+
+    # L'utilisateur re-clique Enable → SO reprend la main mais le timer reste
+    await enable_switch.async_turn_on()
+    await hass.async_block_till_done()
+
+    assert device.is_enabled is True
+    # Le timer est toujours là — c'est l'arrêt du device qui l'annulera
+    assert device.forced_end_time is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 18 : le coordinator éteint le device → timer annulé
+# ---------------------------------------------------------------------------
+
+async def test_coordinator_deactivate_clears_forced_timer(
+    hass: HomeAssistant, init_solar_optimizer_central_config
+):
+    """Quand SO reprend la main et éteint le device via deactivate(),
+    le timer forcé doit être annulé et l'attribut HA mis à jour."""
+    device, _ = await _setup_device(hass)
+
+    device_switch = search_entity(
+        hass, "switch.solar_optimizer_equipement_a", SWITCH_DOMAIN
+    )
+    assert device_switch is not None
+
+    device.activate = AsyncMock()
+
+    # Démarre l'activation forcée
+    await device.start_forced(duration_hours=4)
+    await hass.async_block_till_done()
+
+    assert device.forced_end_time is not None
+    assert device.is_enabled is False
+
+    # Simule le coordinator qui reprend la main : il appelle deactivate() directement
+    await device.deactivate()
+    await hass.async_block_till_done()
+
+    # Le timer doit être annulé
+    assert device.forced_end_time is None
+
+    # L'attribut du switch HA doit refléter forced_end_time=None
+    attrs = device_switch.get_attr_extra_state_attributes
+    assert attrs.get("forced_end_time") is None


### PR DESCRIPTION
Backend
- managed_device: add _forced_end_time attribute, start_forced(), stop_forced(), expire_forced_activation() and set_forced_end_time() methods; forced_end_time property; deactivate() clears the timer if still active so the coordinator loop always cleans up correctly
- switch: ManagedDeviceSwitch inherits RestoreEntity; restores forced_end_time on HA restart; exposes forced_end_time attribute (ISO 8601); ManagedDeviceEnable listens to SOLAR_OPTIMIZER_ENABLE_STATE_CHANGE to keep its HA state in sync; async_turn_off clears the timer when the device is stopped manually
- coordinator: calls expire_forced_activation() on every cycle to auto- stop devices whose timer has expired and re-enable SO management
- __init__: registers solar_optimizer.start_device and solar_optimizer.stop_device services
- services.yaml: declares start_device (device_id, optional duration) and stop_device (device_id)
- const: SERVICE_START_DEVICE, SERVICE_STOP_DEVICE

Frontend
- Duration selector (1h / 4h / 12h / 24h) next to the START button
- When a forced activation is running the selector is replaced by a remaining-time badge (hours if ≥ 1 h, minutes otherwise)
- START with duration → solar_optimizer.start_device service
- STOP during forced activation → solar_optimizer.stop_device service
- 30 s ticker to refresh the remaining-time display
- disconnectedCallback clears the ticker on card removal
- New CSS classes: so-duration-select, so-timed-remaining
- New translation keys: timedDurationSelect, timedRemaining, timedDuration1h/4h/12h/24h (fr + en)

Tests
- New test file tests/test_timed_activation.py: 20 tests covering initial state, start_forced with/without duration, stop_forced, expire_forced_activation (expired / not yet / no timer), set_forced_end_time restore (future / past), forced_end_time switch attribute, all valid durations, Enable button sync (turn off on start_forced, turn on after expiry, no change on stop_forced), device stop clears timer, Enable turn_on does not clear timer

Docs
- README-fr.md + README.md: release note 3.8.1, TOC entries for start_device / stop_device, new action sections, updated "Available Actions" card section with duration selector description
- manifest.json: version 3.8.0 → 3.8.1